### PR TITLE
トークンチェックによるCSRF防止機能を追加する

### DIFF
--- a/src/main/resources/web-component-configuration.xml
+++ b/src/main/resources/web-component-configuration.xml
@@ -10,8 +10,6 @@
   <!-- jsr310 -->
   <import file="JSR310.xml" />
   
-  <component name="dialect" class="nablarch.core.db.dialect.H2Dialect" />
-
   <!-- 環境設定ファイル -->
   <config-file file="env.properties" />
   <config-file file="common.properties" />
@@ -73,6 +71,10 @@
   <!-- スレッドコンテキストハンドラ -->
   <import file="nablarch/webui/threadcontext-for-webui-in-sessionstore.xml"/>
 
+  <!-- CSRF対策 -->
+  <component name="csrfTokenVerificationHandler"
+             class="nablarch.fw.web.handler.CsrfTokenVerificationHandler" />
+
   <!-- ハンドラキュー構成 -->
   <component name="webFrontController"
              class="nablarch.fw.web.servlet.WebFrontController">
@@ -121,6 +123,8 @@
         </component>
 
         <component-ref name="nablarchTagHandler"/>
+
+        <component-ref name="csrfTokenVerificationHandler" />
 
         <component-ref name="dbConnectionManagementHandler"/>
 

--- a/src/test/java/com/nablarch/example/app/test/NopHandler.java
+++ b/src/test/java/com/nablarch/example/app/test/NopHandler.java
@@ -1,0 +1,19 @@
+package com.nablarch.example.app.test;
+
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpRequest;
+import nablarch.fw.web.HttpRequestHandler;
+import nablarch.fw.web.HttpResponse;
+
+/**
+ * 何も処理しないハンドラ。
+ * <p>
+ * テスト時に処理を行いたくないハンドラを差し替えるのに使用する。
+ * </p>
+ */
+public class NopHandler implements HttpRequestHandler {
+    @Override
+    public HttpResponse handle(HttpRequest request, ExecutionContext context) {
+        return context.handleNext(request);
+    }
+}

--- a/src/test/resources/override_test.xml
+++ b/src/test/resources/override_test.xml
@@ -5,7 +5,12 @@
         xsi:schemaLocation="http://tis.co.jp/nablarch/component-configuration https://nablarch.github.io/schema/component-configuration.xsd">
 
   <import file="nablarch/core/date_test.xml"/>
+
   <!-- トークンをHTTPセッションに保存する -->
   <component name="tokenManager" class="nablarch.common.web.token.HttpSessionTokenManager"/>
+
+  <!-- CSRF対策の無効化 -->
+  <component name="csrfTokenVerificationHandler"
+             class="com.nablarch.example.app.test.NopHandler" />
 
 </component-configuration>


### PR DESCRIPTION
ExampleにCSRF対策を追加しました。

以下の動作確認を実施済みです。

- [x] 正しい画面遷移だとCSRFエラーにならない。
- [x] CSRFトークンのパラメータがないとCSRFエラーになる。
- [x] CSRFトークンのパラメータ名だけだとCSRFエラーになる。
- [x] 異なるユーザーのCSRFトークンだとCSRFエラーとなる。
- [x] ログイン前のトークンでログイン後にCSRFエラーとなる。
- [x] NTFのテストが通る。

対応するフレームワーク変更は以下になります。

https://github.com/nablarch/nablarch-fw-web/pull/70
https://github.com/nablarch/nablarch-fw-web-tag/pull/31
https://github.com/nablarch/nablarch-document/pull/287