### PR TITLE
slf4j-nablarch-adaptorを追加（HikariCPのWARN対応）

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.nablarch.integration</groupId>
+      <artifactId>slf4j-nablarch-adaptor</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>javax.ws.rs</groupId>
       <artifactId>javax.ws.rs-api</artifactId>
       <version>2.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,7 @@
     <dependency>
       <groupId>com.nablarch.integration</groupId>
       <artifactId>slf4j-nablarch-adaptor</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
https://github.com/nablarch/slf4j-nablarch-adaptor/pull/1
上記をExampleに反映しました。