### PR TITLE
feat: Java 17 以上でもビルドができるようにプラグインを更新

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -302,6 +302,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
+        <version>3.3.2</version>
         <configuration>
           <webXml>${webxml.path}</webXml>
         </configuration>


### PR DESCRIPTION
Java 17 でビルドすると `mvn package` でエラーになった。
`maven-war-plugin` を最新化することでエラーが発生しなくなったので、バージョンを明示するように修正。

issue は見つけられなかったがバージョンを上げればなおる・なおったという報告はいくつかあった。

https://stdworkflow.com/712/solve-the-error-when-maven-project-is-packaged-error-injecting-constructor
https://stackoverflow.com/questions/67168999/maven-error-cannot-access-defaults-field-of-properties

```log
Caused by: java.lang.ExceptionInInitializerError: Cannot access defaults field of Properties
    at com.thoughtworks.xstream.converters.collections.PropertiesConverter.<clinit> (PropertiesConverter.java:46)
    at com.thoughtworks.xstream.XStream.setupConverters (XStream.java:647)
    at com.thoughtworks.xstream.XStream.<init> (XStream.java:445)
    at com.thoughtworks.xstream.XStream.<init> (XStream.java:385)
    at com.thoughtworks.xstream.XStream.<init> (XStream.java:342)
    at org.apache.maven.plugin.war.util.WebappStructureSerializer.<clinit> (WebappStructureSerializer.java:47)
```