### PR TITLE
fix: ログイン時にセッションIDを変更するだけにした場合はCSRFトークンの再生成を行う必要があったので修正

### DIFF
--- a/src/main/java/com/nablarch/example/app/web/action/AuthenticationAction.java
+++ b/src/main/java/com/nablarch/example/app/web/action/AuthenticationAction.java
@@ -1,6 +1,7 @@
 package com.nablarch.example.app.web.action;
 
 import nablarch.common.dao.UniversalDao;
+import nablarch.common.web.csrf.CsrfTokenUtil;
 import nablarch.common.web.session.SessionUtil;
 import nablarch.core.beans.BeanUtil;
 import nablarch.core.message.ApplicationException;
@@ -72,6 +73,8 @@ public class AuthenticationAction {
         // 認証OKの場合、セッションIDを変更後、
         // 認証情報をセッションに格納後、トップ画面にリダイレクトする。
         SessionUtil.changeId(context);
+        CsrfTokenUtil.regenerateCsrfToken(context);
+
         LoginUserPrincipal userContext = createLoginUserContext(form.getLoginId());
         SessionUtil.put(context, "userContext", userContext);
         SessionUtil.put(context,"user.id",String.valueOf(userContext.getUserId()));


### PR DESCRIPTION
[6.2.18.5. CSRFトークンの再生成を行う](https://nablarch.github.io/docs/5u20/doc/application_framework/application_framework/handlers/web/csrf_token_verification_handler.html#csrf-token-verification-handler-regeneration) にて、ログイン時にセッションIDの再生成だけを行う場合は CSRF トークンの再生成が必要であることが説明されていたので、実装を修正しました。