### PR TITLE
UniversalDao#findBySqlFileに渡しているパラメータの型修正

### DIFF
--- a/src/main/java/com/nablarch/example/app/web/action/ProjectAction.java
+++ b/src/main/java/com/nablarch/example/app/web/action/ProjectAction.java
@@ -256,7 +256,7 @@ public class ProjectAction {
         LoginUserPrincipal userContext = SessionUtil.get(context, "userContext");
 
         ProjectDto dto = UniversalDao.findBySqlFile(ProjectDto.class, "FIND_BY_PROJECT",
-                new Object[] {targetForm.getProjectId(), userContext.getUserId()});
+                new Object[] {Integer.parseInt(targetForm.getProjectId()), userContext.getUserId()});
 
         // 出力情報をリクエストスコープにセット
         context.setRequestScopedVar("form", dto);
@@ -287,7 +287,7 @@ public class ProjectAction {
         LoginUserPrincipal userContext = SessionUtil.get(context, "userContext");
 
         ProjectDto dto = UniversalDao.findBySqlFile(ProjectDto.class, "FIND_BY_PROJECT",
-                new Object[] {targetForm.getProjectId(), userContext.getUserId()});
+                new Object[] {Integer.parseInt(targetForm.getProjectId()), userContext.getUserId()});
 
         // 出力情報をリクエストスコープにセット
         context.setRequestScopedVar("form", dto);

--- a/src/main/java/com/nablarch/example/app/web/common/authentication/SystemAccountAuthenticator.java
+++ b/src/main/java/com/nablarch/example/app/web/common/authentication/SystemAccountAuthenticator.java
@@ -1,6 +1,6 @@
 package com.nablarch.example.app.web.common.authentication;
 
-import java.util.Date;
+import java.sql.Date;
 
 import nablarch.common.dao.NoDataException;
 import nablarch.common.dao.UniversalDao;
@@ -96,8 +96,8 @@ public class SystemAccountAuthenticator implements PasswordAuthenticator {
             throw new AuthenticationFailedException(userId);
         }
 
-        // 有効期限は日付単位で管理しているので、現在日時から時間を切り捨てた日付を使用する。
-        final Date sysDate = DateUtil.getDate(SystemTimeUtil.getDateString());
+        // 有効期限は日付単位で管理しているので、現在日時から時間を切り捨てた日付(java.sql.Date)を使用する。
+        final Date sysDate = new Date(DateUtil.getDate(SystemTimeUtil.getDateString()).getTime());
         final SystemAccount account;
         try {
             account = UniversalDao.findBySqlFile(


### PR DESCRIPTION
# 概要

`UniversalDao#findBySqlFile`のバインドパラメータとして渡している型が一部H2でしか動作しないものになっているので、適切な型に変更するように修正します。

対象は以下です。

- `SYSTEM_ACCOUNT`テーブル検索時の`PASSWORD_EXPIRATION_DATE`を`java.util.Date`から`java.sql.Date`へ
- `PROJECT`テーブル検索時の`PROJECT_ID`を`String`から`int`へ

# 検出事象

nablarch-example-webプロジェクトで使用するデータベースをPostgreSQLに変更すると、実行時に以下の事象が発生します。

## ログイン時にシステムエラーが発生する

ログイン時に`PASSWORD_EXPIRATION_DATE`に指定しているパラメータが`java.sql.Date`のため、PostgreSQLのJDBCドライバで解釈できずに失敗します。

```shell
2022-09-29 11:39:24.703 -FATAL- nablarch.core.log.app.FailureLogUtil [202209291139238260002] boot_proc = [] proc_sys = [nablarch-example-web] req_id = [/action/login] usr_id = [999999999] fail_code = [MSG99999] an unexpected exception occurred.
Input Data :
null
Stack Trace Information :
nablarch.core.db.DbAccessException: failed to setObject.
        at nablarch.core.db.statement.BasicSqlPStatement.setObject(BasicSqlPStatement.java:704)
        at nablarch.common.dao.BasicDaoContext.executeQuery(BasicDaoContext.java:151)
        at nablarch.common.dao.BasicDaoContext.findBySqlFile(BasicDaoContext.java:254)
        at nablarch.common.dao.UniversalDao.findBySqlFile(UniversalDao.java:165)
        at com.nablarch.example.app.web.common.authentication.SystemAccountAuthenticator.authenticate(SystemAccountAuthenticator.java:103)
        at com.nablarch.example.app.web.common.authentication.AuthenticationUtil.authenticate(AuthenticationUtil.java:64)
        at com.nablarch.example.app.web.action.AuthenticationAction.login(AuthenticationAction.java:66)

〜省略〜

Caused by: org.postgresql.util.PSQLException: java.util.Date のインスタンスに対して使うべきSQL型を推測できません。明示的な Types 引数をとる setObject() で使うべき型を指定してください。
        at org.postgresql.jdbc.PgPreparedStatement.setObject(PgPreparedStatement.java:1050)
        at com.zaxxer.hikari.pool.HikariProxyPreparedStatement.setObject(HikariProxyPreparedStatement.java)
        at nablarch.core.db.statement.BasicSqlPStatement.setObject(BasicSqlPStatement.java:701)
        ... 84 more
```

## プロジェクトの参照時にエラーになる

プロジェクトの参照時に、`PROJECT_ID`に`String`を渡しているため型変換エラーになります。

```shell
2022-09-29 11:46:29.443 -FATAL- nablarch.core.log.app.FailureLogUtil [202209291146292870005] boot_proc = [] proc_sys = [nablarch-example-web] req_id = [/action/project/show/1] usr_id = [105] fail_code = [MSG99999] an unexpected exception occurred.
Input Data :
null
Stack Trace Information :
nablarch.core.db.statement.exception.SqlStatementException: failed to executeQuery. SQL = [SELECT PROJECT.PROJECT_ID, PROJECT.PROJECT_NAME, PROJECT.PROJECT_TYPE, PROJECT.PROJECT_CLASS, PROJECT.PROJECT_START_DATE, PROJECT.PROJECT_END_DATE, PROJECT.CLIENT_ID, PROJECT.PROJECT_MANAGER, PROJECT.PROJECT_LEADER, PROJECT.USER_ID, PROJECT.NOTE, PROJECT.SALES, PROJECT.COST_OF_GOODS_SOLD, PROJECT.SGA, PROJECT.ALLOCATION_OF_CORP_EXPENSES, PROJECT.VERSION, CLIENT.CLIENT_NAME FROM PROJECT INNER JOIN CLIENT ON PROJECT.CLIENT_ID = CLIENT.CLIENT_ID WHERE PROJECT.PROJECT_ID = ? AND PROJECT.USER_ID = ?]
        at nablarch.core.db.statement.exception.BasicSqlStatementExceptionFactory.createSqlStatementException(BasicSqlStatementExceptionFactory.java:32)
        at nablarch.core.db.statement.BasicSqlPStatement$SqlExecutor.doSql(BasicSqlPStatement.java:1316)
        at nablarch.core.db.statement.BasicSqlPStatement.executeQuery(BasicSqlPStatement.java:468)
        at nablarch.common.dao.BasicDaoContext.executeQuery(BasicDaoContext.java:153)
        at nablarch.common.dao.BasicDaoContext.findBySqlFile(BasicDaoContext.java:254)
        at nablarch.common.dao.UniversalDao.findBySqlFile(UniversalDao.java:165)
        at com.nablarch.example.app.web.action.ProjectAction.show(ProjectAction.java:258)

〜省略〜

Caused by: org.postgresql.util.PSQLException: ERROR: operator does not exist: integer = character varying
  ヒント: No operator matches the given name and argument types. You might need to add explicit type casts.
  位置: 473
  場所: ファイル: parse_oper.c, ルーチン: op_error,行: 647
  サーバ SQLState: 42883
        at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2676)
        at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2366)
        at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:356)
        at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:496)
        at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:413)
        at org.postgresql.jdbc.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:190)
        at org.postgresql.jdbc.PgPreparedStatement.executeQuery(PgPreparedStatement.java:134)
        at com.zaxxer.hikari.pool.ProxyPreparedStatement.executeQuery(ProxyPreparedStatement.java:52)
        at com.zaxxer.hikari.pool.HikariProxyPreparedStatement.executeQuery(HikariProxyPreparedStatement.java)
        at nablarch.core.db.statement.BasicSqlPStatement$2.execute(BasicSqlPStatement.java:442)
        at nablarch.core.db.statement.BasicSqlPStatement$2.execute(BasicSqlPStatement.java:431)
        at nablarch.core.db.statement.BasicSqlPStatement$SqlExecutor.doSql(BasicSqlPStatement.java:1298)
        ... 83 more
```

# 修正の動機

nablarch-example-webはH2を前提に作成しているので、H2の仕様にある程度依存したものでよいとは思うのですが、今回の2つ（特に`Date`）は一般のJDBCドライバとデータベース型のマッピングとは異なるので修正した方がよいと思いました。

見たところ、`java.util.Date`をそのまま扱えるのはH2のみですね。

- [H2](http://www.h2database.com/html/datatypes.html)
- [PostgreSQL](https://www.enterprisedb.com/docs/jdbc_connector/latest/11_reference_jdbc_data_types/)
- [Oracle](https://docs.oracle.com/cd/F19136_01/jjdbc/accessing-and-manipulating-Oracle-data.html#GUID-1AF80C90-DFE6-4A3E-A407-52E805726778)
- [Db2](https://www.ibm.com/docs/en/db2-for-zos/12?topic=jsri-data-types-that-map-database-data-types-in-java-applications)

# 確認

以下の確認を行いました。

- ソースコードのみを修正した状態
  - `mvn test`を実行し、テストがすべて合格すること
  - アプリケーションを起動し、以下の操作ができること
    - ログインができること
    - パスワードを有効期限を過去にしたアカウントではログインできないこと
    - プロジェクトの参照、更新ができること
 - 加えて、接続先をPostgreSQLに変更
  - アプリケーションを起動し、以下の操作ができること
    - ログインができること
    - パスワードを有効期限を過去にしたアカウントではログインできないこと
    - プロジェクトの参照、更新ができること

# 補足

`SystemAccountAuthenticator`の問題は、最初なかなかわかりませんでした。

エンティティは`java.util.Date`で日付のプロパティが生成され、そのまま`UniversalDao`のCRUDの機能を使って問題がなかったからです。

ドキュメントからすると、CRUDは

> ユニバーサルDAOでは、 `@Temporal` を使用して、 java.util.Date 及び java.util.Calendar 型の値をデータベースにマッピングする方法を指定することができる。

により変換され、SQLファイルによる検索は

> データベースへの出力時
>
>         データベースアクセス(JDBCラッパー) に処理を委譲して変換を行う。

なので、検索条件は`java.sql.Date`を明示的に渡さないとうまくいかない、ということだと読み取っています。

- [ユニバーサルDAO / 使用方法 / 型を変換する](https://nablarch.github.io/docs/5u21/doc/application_framework/application_framework/libraries/database/universal_dao.html#id8)

ドキュメントをちゃんと読めばわかるんですが、わかりづらいですね…（example自身が誤っているのは、その一例だと思います）。  
というのと、H2はそれでよしなに動いてしまっていたので理解が難しかったです。

ドキュメントにも「Entityから自動的に生成したSQLを実行する場合」には`@Temporal`の説明をそれなりに書いているので、「任意のSQLで検索する場合」の方ではバインドパラメータに`java.sql.Date`を使う話を少しピックアップしてもよいのではないかなと思いました。