### PR TITLE
NTF/HTTPテストでHTTPメソッド指定可能にする対応で、インスペクションの警告を修正 

### DIFF
--- a/src/test/java/com/nablarch/example/app/test/advice/SignedInAdvice.java
+++ b/src/test/java/com/nablarch/example/app/test/advice/SignedInAdvice.java
@@ -59,7 +59,6 @@ public class SignedInAdvice extends BasicAdvice {
     }
 
     /**
-     * {@inheritDoc}
      * テストの事前処理を実装する。
      * <p>
      * 本メソッド実行前にログイン処理が自動実行される。

--- a/src/test/java/com/nablarch/example/app/web/action/ProjectBulkActionRequestTest.java
+++ b/src/test/java/com/nablarch/example/app/web/action/ProjectBulkActionRequestTest.java
@@ -42,7 +42,6 @@ class ProjectBulkActionRequestTest {
                         context.getRequestScopedVar("searchForm"));
 
                 // プロジェクト表示結果の確認
-                //noinspection unchecked
                 support.assertBeanList(testCaseInfo.getSheetName(), "projectListDto", testCaseInfo,
                         (List<Object>) BeanUtil.getProperty(context.getRequestScopedVar("bulkForm"), "projectList"));
             }
@@ -65,12 +64,10 @@ class ProjectBulkActionRequestTest {
                         context.getRequestScopedVar("searchForm"));
 
                 // プロジェクト表示結果の確認
-                //noinspection unchecked
                 support.assertBeanList(testCaseInfo.getSheetName(), "projectListDto", testCaseInfo,
                         (List<Object>) BeanUtil.getProperty(context.getRequestScopedVar("bulkForm"), "projectList"));
 
                 // 検索結果がセッションに格納されていることの確認
-                //noinspection unchecked
                 support.assertBeanList(testCaseInfo.getSheetName(), "projectListDtoInSession", testCaseInfo,
                         (List<Object>) BeanUtil.getProperty(SessionUtil.get(context, "projectListDto"), "projectList"));
 
@@ -141,7 +138,6 @@ class ProjectBulkActionRequestTest {
                                      ExecutionContext context) {
 
                 // 更新内容が上書きされたことを確認する
-                //noinspection unchecked
                 support.assertBeanList(testCaseInfo.getSheetName(), "projectListDtoInSession", testCaseInfo,
                         (List<Object>) BeanUtil.getProperty(SessionUtil.get(context, "projectListDto"), "projectList"));
             }
@@ -200,7 +196,6 @@ class ProjectBulkActionRequestTest {
                         context.getRequestScopedVar("searchForm"));
 
                 // プロジェクト表示結果の確認
-                //noinspection unchecked
                 support.assertBeanList(testCaseInfo.getSheetName(), "projectListDto", testCaseInfo,
                         (List<Object>) BeanUtil.getProperty(context.getRequestScopedVar("bulkForm"), "projectList"));
             }

--- a/src/test/java/com/nablarch/example/app/web/action/ProjectBulkActionRequestTest.java
+++ b/src/test/java/com/nablarch/example/app/web/action/ProjectBulkActionRequestTest.java
@@ -42,6 +42,7 @@ class ProjectBulkActionRequestTest {
                         context.getRequestScopedVar("searchForm"));
 
                 // プロジェクト表示結果の確認
+                //noinspection unchecked
                 support.assertBeanList(testCaseInfo.getSheetName(), "projectListDto", testCaseInfo,
                         (List<Object>) BeanUtil.getProperty(context.getRequestScopedVar("bulkForm"), "projectList"));
             }
@@ -64,10 +65,12 @@ class ProjectBulkActionRequestTest {
                         context.getRequestScopedVar("searchForm"));
 
                 // プロジェクト表示結果の確認
+                //noinspection unchecked
                 support.assertBeanList(testCaseInfo.getSheetName(), "projectListDto", testCaseInfo,
                         (List<Object>) BeanUtil.getProperty(context.getRequestScopedVar("bulkForm"), "projectList"));
 
                 // 検索結果がセッションに格納されていることの確認
+                //noinspection unchecked
                 support.assertBeanList(testCaseInfo.getSheetName(), "projectListDtoInSession", testCaseInfo,
                         (List<Object>) BeanUtil.getProperty(SessionUtil.get(context, "projectListDto"), "projectList"));
 
@@ -138,6 +141,7 @@ class ProjectBulkActionRequestTest {
                                      ExecutionContext context) {
 
                 // 更新内容が上書きされたことを確認する
+                //noinspection unchecked
                 support.assertBeanList(testCaseInfo.getSheetName(), "projectListDtoInSession", testCaseInfo,
                         (List<Object>) BeanUtil.getProperty(SessionUtil.get(context, "projectListDto"), "projectList"));
             }
@@ -163,7 +167,7 @@ class ProjectBulkActionRequestTest {
                                                  ExecutionContext context) {
 
                 ProjectListDto projectListDto = new ProjectListDto();
-                MockEntityList<Project> projectList = new MockEntityList<Project>();
+                MockEntityList<Project> projectList = new MockEntityList<>();
                 projectList.setUpMockList(1, 20L, 1);
                 projectListDto.setProjectList(projectList);
 
@@ -196,6 +200,7 @@ class ProjectBulkActionRequestTest {
                         context.getRequestScopedVar("searchForm"));
 
                 // プロジェクト表示結果の確認
+                //noinspection unchecked
                 support.assertBeanList(testCaseInfo.getSheetName(), "projectListDto", testCaseInfo,
                         (List<Object>) BeanUtil.getProperty(context.getRequestScopedVar("bulkForm"), "projectList"));
             }


### PR DESCRIPTION
- src/test/java/com/nablarch/example/app/test/advice/SignedInAdvice.java
    - 不要なinheritDocを削除
- src/test/java/com/nablarch/example/app/web/action/ProjectBulkActionRequestTest.java
    - [チェックされていないキャストの警告](https://github.com/nablarch/nablarch-example-web/pull/104/files#diff-bf57209e29d9386fddfddadaf9ded646de8c82a025081bcf4db965d95b24c3d3R45)
        - テストで問題ないと判断し、サプレスとしました。
        - 複数あり