### PR TITLE
二重にnablarch_submit関数が呼び出されないよう修正

### DIFF
--- a/src/main/webapp/WEB-INF/view/project/update.jsp
+++ b/src/main/webapp/WEB-INF/view/project/update.jsp
@@ -26,12 +26,12 @@
                     <div class="button-nav">
                         <n:forInputPage>
                             <n:a href="/action/project/show/${project.projectId}" cssClass="btn btn-raised btn-default">戻る</n:a>
-                            <n:submit value="削除" uri="#" id="topDeleteButton" cssClass="btn btn-raised btn-danger" allowDoubleSubmission="false" type="button" />
-                            <n:submit value="更新" uri="#" id="topUpdateButton" cssClass="btn btn-raised btn-success" type="button" />
+                            <n:submit value="削除" uri="#" id="topDeleteButton" cssClass="btn btn-raised btn-danger" type="button" allowDoubleSubmission="false" suppressDefaultSubmit="true" />
+                            <n:submit value="更新" uri="#" id="topUpdateButton" cssClass="btn btn-raised btn-success" type="button" suppressDefaultSubmit="true" />
                         </n:forInputPage>
                         <n:forConfirmationPage>
-                            <n:submit value="入力へ戻る" uri="#" id="topBackButton" cssClass="btn btn-raised btn-default" type="button" />
-                            <n:submit value="確定" uri="#" id="topSubmitButton" cssClass="btn btn-raised btn-success" allowDoubleSubmission="false" type="button" />
+                            <n:submit value="入力へ戻る" uri="#" id="topBackButton" cssClass="btn btn-raised btn-default" type="button" suppressDefaultSubmit="true" />
+                            <n:submit value="確定" uri="#" id="topSubmitButton" cssClass="btn btn-raised btn-success" type="button" allowDoubleSubmission="false" suppressDefaultSubmit="true" />
                         </n:forConfirmationPage>
                     </div>
                 </div>

--- a/src/main/webapp/WEB-INF/view/projectBulk/update.jsp
+++ b/src/main/webapp/WEB-INF/view/projectBulk/update.jsp
@@ -44,7 +44,7 @@
                                         </span>
                                         <n:set var="isUpdatable" value="${fn:length(projectListDto.projectList) == 0 ? 'disabled' : ''}" />
                                         <div class="button-nav">
-                                            <button id="topUpdateButton" class="btn btn-raised btn-success" <n:write name="isUpdatable" />>更新</button>
+                                            <button id="topUpdateButton" class="btn btn-raised btn-success" suppressDefaultSubmit="true" <n:write name="isUpdatable" />>更新</button>
                                             <n:a href="/action/project" cssClass="btn btn-raised btn-default">新規登録</n:a>
                                         </div>
                                     </div>

--- a/src/main/webapp/javascripts/projectInput.js
+++ b/src/main/webapp/javascripts/projectInput.js
@@ -6,10 +6,6 @@ $(function() {
     $("#bottomUpdateButton").click();
   });
 
-  $("#topCreateButton").click(function() {
-    $("#bottomCreateButton").click();
-  });
-
   $("#topDeleteButton").click(function() {
     $("#bottomDeleteButton").click();
   });


### PR DESCRIPTION
画面上部にあるボタンがダミーであるにも関わらず、`nablarch_submit`関数が複数回呼び出され、かつ`form`本来の処理は実行されないという不可解な状態を修正しました。

ダミーの要素には`suppressDefaultSubmit`属性を`true`に設定して、`nablarch_sutmit`関数を呼び出さなくなりました。  
jQueryを使ったイベントの発火は引き続き行われます。

コードを見て、気になるであろう箇所について説明しておきます。

- `topCreateButton`という`id`を設定されたは存在しないのでイベントハンドリングを行っている個所を削除
  - `topCreateButton`新規登録ボタンのこと（not登録ボタン）
  - ではどうしているのかというと、このボタンが配置されている新規登録画面は、他の画面と違って`n:form`がひとつしかないから
    - 他の画面はどうしてこの実装にならなかったのか…

---

また、今回はCSP対応の時のコメント（長い）から`suppressDefaultSubmit`という命名にしたのですが、サブミットに関する属性は`allowDoubleSubmission`のように`Submission`にする感じですね…。  
今回のように属性が並ばれると違和感があったので、統一性のため`suppressDefaultSubmission`にリネームしましょうか？
※ちょっと長めになりますが…

現在のイメージ。

```jsp
<n:submit value="確定" uri="#" id="topSubmitButton" cssClass="btn btn-raised btn-success" type="button" allowDoubleSubmission="false" suppressDefaultSubmit="true" />
```

変更した場合。

```jsp
<n:submit value="確定" uri="#" id="topSubmitButton" cssClass="btn btn-raised btn-success" type="button" allowDoubleSubmission="false" suppressDefaultSubmission="true" />
```