### PR TITLE
依存ライブラリの更新

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
-        <version>5.8.2</version>
+        <version>5.11.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -202,23 +202,10 @@
       <groupId>com.nablarch.framework</groupId>
       <artifactId>nablarch-testing-rest</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.eclipse.jdt.core.compiler</groupId>
-          <artifactId>ecj</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.nablarch.framework</groupId>
       <artifactId>nablarch-testing-jetty12</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.eclipse.jdt.core.compiler</groupId>
-      <artifactId>ecj</artifactId>
-      <version>4.5.1</version>
       <scope>test</scope>
     </dependency>
 
@@ -238,13 +225,13 @@
     <dependency>
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path-assert</artifactId>
-      <version>2.4.0</version>
+      <version>2.9.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.skyscreamer</groupId>
       <artifactId>jsonassert</artifactId>
-      <version>1.5.0</version>
+      <version>1.5.3</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
以下の対応を実施
- org.eclipse.jdt.core.compiler:ecj への依存を削除
- json-pathの最新化
- JSONassertの最新化
- Junit 5の最新化