### PR TITLE
Jettyの一時ディレクトリをtarget配下に変更したため、不要になったmaven-clean-pluginのwork/jsp 削除の定義を削除

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -324,17 +324,6 @@
           <webXml>${webxml.path}</webXml>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-clean-plugin</artifactId>
-        <configuration>
-          <filesets>
-            <fileset>
-              <directory>work/jsp</directory>
-            </fileset>
-          </filesets>
-        </configuration>
-      </plugin>
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
https://github.com/nablarch/nablarch-default-configuration/pull/34 より、maven-clean-plugin による work/jsp 削除が不要になったため対応しました。