### PR TITLE
Jettyで起動した際にJSTLのJARが重複する警告が出力されるので、Webアプリ側には含めないようにして警告を抑制

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -338,6 +338,12 @@
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-maven-plugin</artifactId>
         <version>12.0.3</version>
+        <configuration>
+          <webApp>
+            <!-- Jettyに含まれるJSTLと重複するので、Webアプリに含まれるJSTLはJettyで起動する際には除外する -->
+            <webInfIncludeJarPattern><![CDATA[.*/[^/]+(?<!jakarta\.servlet\.jsp\.jstl-[^/]+)\.jar$]]></webInfIncludeJarPattern>
+          </webApp>
+        </configuration>
       </plugin>
       <!-- カバレッジ取得 -->
       <plugin>


### PR DESCRIPTION
nablarch-fw-web-tagにJSTL（API、実装）が含まれるがJettyにもJSTLは含まれているため、`mvn jetty:run`で起動した際にJARに含まれるクラスが重複していることを警告されるので修正。

具体的には、Webアプリ側に含まれてるJSTL（API、実装）をJettyにデプロイする際に除外するように設定した。

動作確認としては以下を実施。

- nablarch-example-webのひととおりの動作確認
- 設定適用後にJetty Maven Pluginをデバッグし、Webアプリから除外されるのがJSTL（API、実装）ライブラリのみであることを確認
- 修正の方向の妥当性確認のために、JSTLをnablarch-example-webから除外し、Tomcatにデプロイして動作しない（ログイン画面が表示できない）ことを確認
  - TomcatにデプロイするためにはJSTLを含める必要があることの再確認
  - WildFlyについてはJSTLを含めても含めなくても動作する（ログイン画面を表示できる）ことを確認